### PR TITLE
TableView - fixed a crash happening when closing window with a scrolled TBV

### DIFF
--- a/enamlx/qt/qt_table_view.py
+++ b/enamlx/qt/qt_table_view.py
@@ -114,7 +114,7 @@ class QtTableView(QtAbstractItemView, ProxyTableView):
         
     def _refresh_visible_row(self, value):
         self._pending_row_refreshes -= 1
-        if self._pending_row_refreshes == 0:
+        if self._pending_row_refreshes == 0 and (self.declaration is not None):
             d = self.declaration
             rows = self.model.rowCount()-d.visible_rows
             d.visible_row = max(0, min(value, rows))


### PR DESCRIPTION
When having a TableView on a window that was not the main window, if the TableView was scrolled down so that the first rows would not be visible anymore, and the user happened to close the window with the TableView, the program would crash.

The crash is because in QtTableView, the method _refresh_visible_row(self) gets called at least once after the user has closed the window, and at that time self.declaration is None, which implies a crash when accessing attributes visible_rows and visible_row.