### PR TITLE
Ensure value coerced to Qt.CheckState enum

### DIFF
--- a/enamlx/qt/qt_abstract_item_view.py
+++ b/enamlx/qt/qt_abstract_item_view.py
@@ -109,7 +109,7 @@ class QAbstractAtomItemModel(object):
             return False
         d = item.declaration
         if role == Qt.CheckStateRole:
-            checked = value == Qt.Checked
+            checked = Qt.CheckState(value) == Qt.CheckState.Checked
             if checked != d.checked:
                 d.checked = checked
                 d.toggled(checked)


### PR DESCRIPTION
This was broken when using Qt6. Attempting to toggle a checkbox in the TreeView example did not work until we coerced the value to ensure proper comparision.